### PR TITLE
Making meta_id more random

### DIFF
--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -36,7 +36,7 @@ module Resque
       # passed the same arguments as `perform`, that is, your job's
       # payload.
       def meta_id(*args)
-        Digest::SHA1.hexdigest([ Time.now.to_f, self, args ].join)
+        Digest::SHA1.hexdigest([ Time.now.to_f, rand, self, args ].join)
       end
 
       # Override in your job to control the how many seconds a job's

--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -36,7 +36,7 @@ module Resque
       # passed the same arguments as `perform`, that is, your job's
       # payload.
       def meta_id(*args)
-        Digest::SHA1.hexdigest([ Time.now.to_i, self, args ].join)
+        Digest::SHA1.hexdigest([ Time.now.to_f, self, args ].join)
       end
 
       # Override in your job to control the how many seconds a job's


### PR DESCRIPTION
Hi, meta_id is currently generated with Time.now.to_i which has only seconds resolution, so multiple jobs with the same args enqueued within the same second will have the same meta_id. This was futzing up my tests.

I made two changes: 1) Use Time.now.to_f which has microsecond resolution, to the args used to generated meta_id, and also 2) throw a call to 'rand' in for good measure.

thanks,
Cory
