### PR TITLE
Allow default meta key TTL to be overridable

### DIFF
--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -48,12 +48,13 @@ module Resque
       end
 
       # Override in your job to control how many seconds a job's 
-      # metadata will live *before* it finishes.  This includes the condition
+      # metadata will live after it is enqueued and *before* it finishes.  
+      # This includes the condition
       # where the job and metadata are never finished because of a 
       # shutdown or server crash. Defaults to 0 (i.e. 
       # forever).  Return nil or 0 to set them to never expire. 
-      # Use caution: this value should be longer than your jobs take to run! 
-      def expire_meta_default_in
+      # Use caution: this value should be longer than your jobs take to run!
+      def before_finish_expire_in
         0
       end
 

--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -47,6 +47,16 @@ module Resque
         24 * 60 * 60
       end
 
+      # Override in your job to control how many seconds a job's 
+      # metadata will live *before* it finishes.  This includes the condition
+      # where the job and metadata are never finished because of a 
+      # shutdown or server crash. Defaults to 0 (i.e. 
+      # forever).  Return nil or 0 to set them to never expire. 
+      # Use caution: this value should be longer than your jobs take to run! 
+      def expire_meta_default_in
+        0
+      end
+
       # Enqueues a job in Resque and return the association metadata.
       # The meta_id in the returned object can be used to fetch the
       # metadata again in the future.

--- a/lib/resque/plugins/meta/metadata.rb
+++ b/lib/resque/plugins/meta/metadata.rb
@@ -4,7 +4,7 @@ module Resque
   module Plugins
     module Meta
       class Metadata
-        attr_reader :job_class, :meta_id, :data, :enqueued_at, :expire_in
+        attr_reader :job_class, :meta_id, :data, :enqueued_at, :expire_in, :expire_default_in
 
         def initialize(data_hash)
           data_hash['enqueued_at'] ||= to_time_format_str(Time.now)
@@ -18,6 +18,7 @@ module Resque
             data_hash['job_class'] = @job_class.to_s
           end
           @expire_in = @job_class.expire_meta_in || 0
+          @expire_default_in = @job_class.expire_meta_default_in || 0
         end
 
         # Reload the metadata from the store
@@ -64,8 +65,13 @@ module Resque
         end
 
         def expire_at
+          # expiry after finished
           if finished? && expire_in > 0
             finished_at.to_i + expire_in
+          # expiry after enqueued
+          elsif expire_default_in > 0
+            enqueued_at.to_i + expire_default_in
+          # default ttl is forever
           else
             0
           end

--- a/lib/resque/plugins/meta/metadata.rb
+++ b/lib/resque/plugins/meta/metadata.rb
@@ -4,7 +4,7 @@ module Resque
   module Plugins
     module Meta
       class Metadata
-        attr_reader :job_class, :meta_id, :data, :enqueued_at, :expire_in, :expire_default_in
+        attr_reader :job_class, :meta_id, :data, :enqueued_at, :expire_in, :before_finish_expire_in
 
         def initialize(data_hash)
           data_hash['enqueued_at'] ||= to_time_format_str(Time.now)
@@ -18,7 +18,7 @@ module Resque
             data_hash['job_class'] = @job_class.to_s
           end
           @expire_in = @job_class.expire_meta_in || 0
-          @expire_default_in = @job_class.expire_meta_default_in || 0
+          @before_finish_expire_in = @job_class.before_finish_expire_in || 0
         end
 
         # Reload the metadata from the store
@@ -69,8 +69,8 @@ module Resque
           if finished? && expire_in > 0
             finished_at.to_i + expire_in
           # expiry after enqueued
-          elsif expire_default_in > 0
-            enqueued_at.to_i + expire_default_in
+          elsif before_finish_expire_in > 0
+            enqueued_at.to_i + before_finish_expire_in
           # default ttl is forever
           else
             0

--- a/test/meta_test.rb
+++ b/test/meta_test.rb
@@ -49,6 +49,18 @@ class FailingJob
   end
 end
 
+class TransientJob
+  extend Resque::Plugins::Meta
+  @queue = :test
+
+  def self.perform(meta_id)
+  end
+
+  def self.expire_meta_default_in
+    1
+  end
+end
+
 class MetaTest < Test::Unit::TestCase
   def setup
     Resque.redis.flushall
@@ -118,6 +130,16 @@ class MetaTest < Test::Unit::TestCase
     sleep 2
     meta = MetaJob.get_meta(meta.meta_id)
     assert_nil meta
+  end
+
+  def test_expired_metadata_before_finished
+    meta = TransientJob.enqueue()
+    worker = Resque::Worker.new(:test)
+    assert meta = TransientJob.get_meta(meta.meta_id)
+
+    sleep 2
+    meta = TransientJob.get_meta(meta.meta_id)
+    assert_equal nil, meta
   end
 
   def test_slow_job

--- a/test/meta_test.rb
+++ b/test/meta_test.rb
@@ -56,7 +56,7 @@ class TransientJob
   def self.perform(meta_id)
   end
 
-  def self.expire_meta_default_in
+  def self.before_finish_expire_in
     1
   end
 end


### PR DESCRIPTION
Hello, 
Thanks for this gem, it has helped me out on a project quite a bit.  We have a situation where there are many jobs, and the system frequently restarts, leaving many meta keys in an unfinished state.  In addition, in our situation, the meta keys are unimportant and not necessary to keep around if the jobs don't finish. For that reason, I added some code to make the default TTL for a meta key overridable, similar to the fashion in which the TTL is configurable for a finished job.  
Test is included.
Cheers,
Billy
