### PR TITLE
expireat fails and meta data does not expire

### DIFF
--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -72,7 +72,7 @@ module Resque
         key = "meta:#{meta.meta_id}"
         json = Resque.encode(meta.data)
         Resque.redis.set(key, json)
-        Resque.redis.expireat("resque:#{key}", meta.expire_at) if meta.expire_at > 0
+        Resque.redis.expireat(key, meta.expire_at) if meta.expire_at > 0
         meta
       end
 

--- a/lib/resque/plugins/meta.rb
+++ b/lib/resque/plugins/meta.rb
@@ -71,8 +71,11 @@ module Resque
       def store_meta(meta)
         key = "meta:#{meta.meta_id}"
         json = Resque.encode(meta.data)
-        Resque.redis.set(key, json)
-        Resque.redis.expireat(key, meta.expire_at) if meta.expire_at > 0
+        if meta.expire_at > 0
+          Resque.redis.setex(key, meta.expire_at - Time.now.to_i, json)
+        else
+          Resque.redis.set(key, json)
+        end
         meta
       end
 


### PR DESCRIPTION
Hi

After some debugging I found a pretty nasty bug:

First of all, when storing the metadata, the wrong key `"resque:#{key}"` is used for the expireat call instead of `key`

```
key = "meta:#{meta.meta_id}"
json = Resque.encode(meta.data)
Resque.redis.set(key, json)
Resque.redis.expireat("resque:#{key}", meta.expire_at) if meta.expire_at > 0
```

But it turns out that as long as you use resque with the default configuration with namespace "resque", everything works as expected.

Due to a bug in redis-namespace, the key passed to expireat is not prepended with the namespace (see https://github.com/defunkt/redis-namespace/pull/26), so the wrong key will actually be correct and everything works as expected.

but as soon as you deviate from the default configuration and use a custom namespace, expireat will silently fail because
- resque-meta uses the wrong key
- resque-namespace does not prepend the namespace to the wrong key
  resulting in a completely wrong key,
  and you begin to wonder why your memory usage of your redis instance steadily grows :)

kind regards
