### PR TITLE
use activesupport's String#constantize instead of relying on resque

### DIFF
--- a/lib/resque/plugins/meta/metadata.rb
+++ b/lib/resque/plugins/meta/metadata.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'active_support/core_ext/string/inflections'
 
 module Resque
   module Plugins
@@ -13,7 +14,7 @@ module Resque
           @enqueued_at = from_time_format_str('enqueued_at')
           @job_class = data_hash['job_class']
           if @job_class.is_a?(String)
-            @job_class = Resque.constantize(data_hash['job_class'])
+            @job_class = data_hash['job_class'].constantize
           else
             data_hash['job_class'] = @job_class.to_s
           end

--- a/resque-meta.gemspec
+++ b/resque-meta.gemspec
@@ -48,6 +48,7 @@ desc
     s.specification_version = 3
 
     s.add_runtime_dependency('resque', ["~> 1.8"])
+    s.add_runtime_dependency('active_support')
     s.add_development_dependency('rake', ["~> 0.9.2"])
     s.add_development_dependency('json')
   else


### PR DESCRIPTION
helpers.

Constantize from resque helpers have been removed as of resque 1.25.1 I
believe, and the rest of them will be completely gone from resque 2.0.

Probably should specify a version of active_support in the gemspec...
